### PR TITLE
Remove qtdds.dll deployment from the fixes project

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ config = {
     'python_version_minor': '.14',
     'sip_version': '4.19.8',
     'qt_version': '5.10',
-    'qt_version_minor': '1',
+    'qt_version_minor': '0',
     'vc_platformtoolset': 'v141',
     'vc_version': '15.0',
     'vc_version_for_boost': '14.1',

--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -152,13 +152,3 @@ if config['Installer']:
 if config['transifex_Enable']:
     from unibuild.projects import translations
     translationsBuild = Project("translationsBuild").depend("translations")
-
-def fix(context):
-    import shutil
-
-    shutil.copy2(os.path.join(qt_inst_path(), "bin", "Qt5WinExtras.dll"), os.path.join(config["paths"]["install"], "bin", "dlls"))
-    return True
-
-
-Project("fixes") \
-    .depend(build.Execute(fix).depend("modorganizer"))

--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -155,13 +155,8 @@ if config['transifex_Enable']:
 
 def fix(context):
     import shutil
-    try:
-        os.makedirs(os.path.join(config["paths"]["install"], "bin", "dlls", "imageformats"))
-    except:
-        pass
 
     shutil.copy2(os.path.join(qt_inst_path(), "bin", "Qt5WinExtras.dll"), os.path.join(config["paths"]["install"], "bin", "dlls"))
-    shutil.copy2(os.path.join(config['paths']['build'], "modorganizer_super", "modorganizer", "qdds.dll"), os.path.join(config["paths"]["install"], "bin", "dlls", "imageformats"))
     return True
 
 


### PR DESCRIPTION
Deploying this file in the fixes project is no longer necessary once https://github.com/Modorganizer2/modorganizer/pull/271 is merged.