### PR TITLE
Remove the fixes project as it is redundant.

### DIFF
--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -155,13 +155,8 @@ if config['transifex_Enable']:
 
 def fix(context):
     import shutil
-    try:
-        os.makedirs(os.path.join(config["paths"]["install"], "bin", "dlls", "imageformats"))
-    except:
-        pass
 
     shutil.copy2(os.path.join(qt_inst_path(), "bin", "Qt5WinExtras.dll"), os.path.join(config["paths"]["install"], "bin", "dlls"))
-    shutil.copy2(os.path.join(config['paths']['build'], "modorganizer_super", "modorganizer", "qdds.dll"), os.path.join(config["paths"]["install"], "bin", "dlls", "imageformats"))
     return True
 
 

--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -153,12 +153,3 @@ if config['transifex_Enable']:
     from unibuild.projects import translations
     translationsBuild = Project("translationsBuild").depend("translations")
 
-def fix(context):
-    import shutil
-
-    shutil.copy2(os.path.join(qt_inst_path(), "bin", "Qt5WinExtras.dll"), os.path.join(config["paths"]["install"], "bin", "dlls"))
-    return True
-
-
-Project("fixes") \
-    .depend(build.Execute(fix).depend("modorganizer"))


### PR DESCRIPTION
https://github.com/Modorganizer2/modorganizer/pull/271 fixed the issue with `QtDDS.dll`

https://github.com/Modorganizer2/modorganizer/pull/268 fixed the issue with `QtWinExtras.dll`

This is a repeat of https://github.com/Modorganizer2/modorganizer-umbrella/pull/9 but without the accidentally committed change to `config.py`