### PR TITLE
Make sure python is in the PATH environment variable

### DIFF
--- a/unibuild/utility/config_setup.py
+++ b/unibuild/utility/config_setup.py
@@ -52,10 +52,12 @@ def init_config(args):
                                                            install_dir=args.installdir)
 
     python = get_from_hklm("HKEY_LOCAL_MACHINE", r"SOFTWARE\Python\PythonCore\{}\InstallPath".format(config['python_version']), "")
+    if python is None:
+        python = get_from_hklm("HKEY_CURRENT_USER", r"SOFTWARE\Python\PythonCore\{}\InstallPath".format(config['python_version']), "")
     if python is not None:
-        config['paths']['python'] = Lazy(lambda: os.path.join(python, "python.exe"))
+        config['paths']['python'] = os.path.join(python, "python.exe")
     else:
-        config['paths']['python'] = Lazy(lambda: os.path.join(get_from_hklm("HKEY_CURRENT_USER", r"SOFTWARE\Python\PythonCore\{}\InstallPath".format(config['python_version']), ""), "python.exe"))
+        config['paths']['python'] = sys.executable
 
     # parse -s argument.  Example -s paths.build=bin would set config[paths][build] to bin
     if args.set:
@@ -91,7 +93,7 @@ def dump_config():
     #logging.debug(" Config: config['paths']['ruby']=%s", config['paths']['ruby'])
     #logging.debug(" Config: config['paths']['svn']=%s", config['paths']['svn'])
     logging.debug("  Config: config['paths']['7z']=%s", config['paths']['7z'])
-    logging.debug("  Config: config['paths']['python']=%s", Evaluate(config['paths']['python']))
+    logging.debug("  Config: config['paths']['python']=%s", config['paths']['python'])
     logging.debug("  Config: config['paths']['visual_studio']=%s", config['paths']['visual_studio'])
     logging.debug("  Config: config['vc_version']=%s", config['vc_version'])
 

--- a/unimake.py
+++ b/unimake.py
@@ -111,6 +111,10 @@ def main():
         logging.error("Missing pre requisite")
         return False
 
+    py_dir = os.path.dirname(config["paths"]["python"])
+    if py_dir.lower() not in os.environ["PATH"].lower().split(os.pathsep):
+        os.environ["PATH"] += os.pathsep + py_dir
+ 
     logging.debug("  Build: args.target=%s", args.target)
     logging.debug("  Build: args.destination=%s", args.destination)
 


### PR DESCRIPTION
I have multiple versions of Python on my Windows system. None of them are in my path. I run unimake.py with an explicit path to Python which works fine, except some of the subprocesses fail because they cannot find python.exe in PATH.

This corrects that by adding Python to PATH, if necessary. Also, if it cannot get the python install path form the registry, it will fallback to the path of the running python executable.