### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Now you need to install all required software to build Mod Organizer.
   * 7zip (Latest 64Bit) Link: http://www.7-zip.org/a/7z1700-x64.exe
   * CMake (latest 64bit)  Link: https://cmake.org/files/v3.10/cmake-3.10.2-win64-x64.msi
   * Git Link: https://github.com/git-for-windows/git/releases/download/v2.16.2.windows.1/Git-2.16.2-64-bit.exe
-  * ~~Python 2.7.14 (64Bit) Link: https://www.python.org/ftp/python/2.7.14/python-2.7.14.msi~~ *If you've previously used a Python 2 version of Umbrella, you may need to run `git clean -xdf` to remove cached data which interferes with Python 3.`
+  * ~~Python 2.7.14 (64Bit) Link: https://www.python.org/ftp/python/2.7.14/python-2.7.14.msi~~ *If you've previously used a Python 2 version of Umbrella, you may need to run `git clean -xdf` to remove cached data which interferes with Python 3.`*
   * Python 3.7 (64Bit) Link: https://www.python.org/downloads/windows/
   * Qt 5.11.1 http://download.qt.io/official_releases/online_installers/qt-unified-windows-x86-online.exe
     #### Qt Packages required:


### PR DESCRIPTION
Apparently the preview in GitHub's online Markdown editor makes things italic even if you've forgotten the closing `*`, even though the main renderer does not. This sorts out a mistake which that caused.