### PR TITLE
Add support for FNISTool

### DIFF
--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -85,6 +85,7 @@ for author, git_path, path, branch, dependencies, Build in [
     (config['Main_Author'], "modorganizer-tool_inieditor", "tool_inieditor", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-tool_inibakery", "tool_inibakery", config['Main_Branch'], ["modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-tool_configurator", "tool_configurator", config['Main_Branch'], ["PyQt5"], True),
+    (config['Main_Author'], "modorganizer-fnistool", "fnistool", config['Main_Branch'], ["PyQt5"], True),
     (config['Main_Author'], "modorganizer-preview_base", "preview_base", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-diagnose_basic", "diagnose_basic", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-check_fnis", "check_fnis", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),


### PR DESCRIPTION
This requires that someone with authority forks https://github.com/AnyOldName3/modorganizer-fnistool to the ModOrganizer2 organisation.

Also, because this is a new plugin, we'll need to upload the `.ts` file to Transifex as it's not there already. I don't know how we've got that set up to work, so don't know how automatic it is.