### PR TITLE
Add ScriptExtenderPluginChecker

### DIFF
--- a/makefile.uni.py
+++ b/makefile.uni.py
@@ -91,6 +91,7 @@ for author, git_path, path, branch, dependencies, Build in [
     (config['Main_Author'], "modorganizer-fnistool", "fnistool", config['Main_Branch'],  ["PyQt5"], True),
     (config['Main_Author'], "modorganizer-preview_base", "preview_base", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-diagnose_basic", "diagnose_basic", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
+    (config['Main_Author'], "modorganizer-script_extender_plugin_checker", "script_extender_plugin_checker", config['Main_Branch'],  ["PyQt5"], True),
     (config['Main_Author'], "modorganizer-check_fnis", "check_fnis", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-installer_bain", "installer_bain", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),
     (config['Main_Author'], "modorganizer-installer_manual", "installer_manual", config['Main_Branch'], ["Qt5", "modorganizer-uibase"], True),


### PR DESCRIPTION
https://github.com/AnyOldName3/modorganizer-script_extender_plugin_checker will need adopting into the organisation.

The plugin will need adding to the list on the main repo readme (and someone could do Enderal while they're at it).

The plugin has been tested, but the CMake stuff hasn't - I just changed some stuff from the FNISTool repo, so it *should* be fine, but my Umbrella is months out of date.

I imagine that this might well fail AppVeyor as it'll link to a repo that doesn't exist yet.