### PR TITLE
master-branch Umbrella should make master-branch MO2

### DIFF
--- a/config.py
+++ b/config.py
@@ -84,7 +84,7 @@ config = {
                                # folders: <project>\<task>_complete.txt
 
     'Main_Author': 'ModOrganizer2',  # the current maintainer
-    'Main_Branch': "Develop",
+    'Main_Branch': "master",
     'Distrib_Author': 'TanninOne',  # the current distribution (and the original Author)
     'Work_Author': '',  # yourself
 


### PR DESCRIPTION
Otherwise, it grabs the wrong dependency versions and doesn't work.