### PR TITLE
Patch for incorrect include directory

### DIFF
--- a/patches/siputils.py.patch
+++ b/patches/siputils.py.patch
@@ -1,0 +1,9 @@
+--- siputils.py	Sat Sep  7 20:22:30 2019
++++ siputils.py	Fri Oct  4 04:42:15 2019
+@@ -441,3 +441,5 @@
+         if self._python:
+-            incdir.append(self.config.py_inc_dir)
++            for inc_dir in self.config.py_inc_dir.split(";"):
++                incdir.append(inc_dir)
++
+             incdir.append(self.config.py_conf_inc_dir)

--- a/unibuild/projects/sip.py
+++ b/unibuild/projects/sip.py
@@ -19,6 +19,8 @@ import errno
 import logging
 import os.path
 import shutil
+import patch
+
 from glob import glob
 from subprocess import Popen
 
@@ -74,6 +76,9 @@ class SipConfigure(build.Builder):
     def process(self, progress):
         soutpath = os.path.join(self._context["build_path"], "stdout.log")
         serrpath = os.path.join(self._context["build_path"], "stderr.log")
+
+        self.patch_siputils()
+
         with open(soutpath, "w") as sout:
             with open(serrpath, "w") as serr:
                 logging.debug("123 %s", python.python['build_path'])
@@ -97,6 +102,13 @@ class SipConfigure(build.Builder):
 
         return True
 
+    def patch_siputils(self):
+        patch_file = os.path.join(config['__Umbrella_path'], "patches", "siputils.py.patch")
+        savedpath = os.getcwd()
+        os.chdir(self._context["build_path"])
+        pset = patch.fromfile(patch_file)
+        pset.apply()
+        os.chdir(savedpath)
 
 if config.get('Appveyor_Build', True):
     Project('sip') \


### PR DESCRIPTION
`py_inc_dir` contains two paths separated by a semi-colon, this splits them and adds both. Fixes #41.