### PR TITLE
Copy uic submodule when copying PyQt5 files.

### DIFF
--- a/unibuild/projects/pyqt5.py
+++ b/unibuild/projects/pyqt5.py
@@ -83,7 +83,7 @@ def copy_files(context):
             )
         except FileNotFoundError:
             pass
-    shutil.rmtree(os.path.join(dstdir, "uic"))
+    shutil.rmtree(os.path.join(dstdir, "uic"), ignore_errors=True)
     shutil.copytree(
         os.path.join(srcdir, "uic"),
         os.path.join(dstdir, "uic"),

--- a/unibuild/projects/pyqt5.py
+++ b/unibuild/projects/pyqt5.py
@@ -83,6 +83,11 @@ def copy_files(context):
             )
         except FileNotFoundError:
             pass
+    shutil.rmtree(os.path.join(dstdir, "uic"))
+    shutil.copytree(
+        os.path.join(srcdir, "uic"),
+        os.path.join(dstdir, "uic"),
+        ignore=shutil.ignore_patterns("__pycache__"))
 
     return True
 


### PR DESCRIPTION
As the title says, and following https://github.com/ModOrganizer2/modorganizer/issues/1065, the idea is to add the `PyQt5.uic` module as a dependency, since it is required to load `.ui` file using PyQt5.

The current module that use `.ui` files ship the `.py` generate files instead of the `.py` ones (e.g., `preview_dds`), which is fine for official plugins with a generation pipeline (these are generated by cmake). For plugins developed by external developers, it is much easier to ship the `.ui` file.

Since this module is a special case, I did not feel like adding it to `enabled_modules` and then add a `if`/`else` block in the `for` loop, but could do if requested.

With https://github.com/ModOrganizer2/modorganizer/issues/1067, this will ease the process of creating larger python plugins I think.