### PR TITLE
Gamebryo translations

### DIFF
--- a/unibuild/task.py
+++ b/unibuild/task.py
@@ -50,6 +50,16 @@ class Task(object):
     def dependencies(self):
         return self.__dependencies
 
+    def depends_on(self, name):
+        for d in self.__dependencies:
+            if d.name == name:
+                return True
+
+            if d.depends_on(name):
+                return True
+
+        return False
+
     @property
     def enabled(self):
         return True

--- a/unibuild/utility/visualstudio.py
+++ b/unibuild/utility/visualstudio.py
@@ -113,5 +113,6 @@ def visual_studio_environment():
     for line in stdout.splitlines():
         if b"=" in line:
             key, value = line.split(b"=", 1)
-            vcenv[key] = value
+            vcenv[key] = value.decode('mbcs')
+
     return vcenv


### PR DESCRIPTION
The game plugins used to duplicate the strings from the gamebryo project. Since the new common cmake files, the gamebryo project has its own `.ts` file and the game plugins only contain their own strings. This now requires merging the `.ts` file from the game plugin and gamebryo when generating the `.qm` files. 

I added a bunch of comments to `GenerateFiles()` because I couldn't figure out what was what. The main change is that it returns arrays of source files instead of a single one, so game plugins can return their own `.ts` file and gamebryo's. To figure out if the gamebryo `.ts` is required, I look up the task by name in the manager and check if it has a direct or indirect dependency on `modorganizer-game_gamebryo`. If it does, I build the path to gamebryo's translation directory and add its `.ts` file to the array.

I also fixed a bad decode for environment strings, they're ACP, not utf8.