### PR TITLE
Boost and ncc

### DIFF
--- a/unibuild/modules/msbuild.py
+++ b/unibuild/modules/msbuild.py
@@ -88,6 +88,7 @@ class MSBuild(Builder):
                           "/verbosity:" + verbosity,
                           "/consoleloggerparameters:Summary",
                           "/fileLogger",
+                          "/property:RunCodeAnalysis=false",
                           "/fileloggerparameters:Summary;Verbosity=" + lverbosity]
 
 

--- a/unibuild/projects/boost.py
+++ b/unibuild/projects/boost.py
@@ -34,7 +34,8 @@ boost_components = ["date_time",
     "filesystem",
     "thread",
     "log",
-    "locale"]
+    "locale",
+    "program_options"]
 boost_components_shared = ["python"]
 
 user_config_jam = "user-config-{}.jam".format("64" if config['architecture'] == "x86_64" else "32")


### PR DESCRIPTION
- Added `program_options` to boost, now required by MO
- Added `RunCodeAnalysis=false` property to msbuild, ncc fails without it